### PR TITLE
fix errors in ILE functions model A

### DIFF
--- a/content/ILE.html
+++ b/content/ILE.html
@@ -218,7 +218,7 @@
 </div>
 </td>
 <td><div class="line-block">
-<div class="line"><strong>Ti</strong></div>
+<div class="line"><strong>Se</strong></div>
 <div class="line">3rd <a class="reference internal" href="functions.html#role-func"><span class="std std-ref">Role function</span></a></div>
 </div>
 </td>
@@ -235,7 +235,7 @@
 </div>
 </td>
 <td><div class="line-block">
-<div class="line"><strong>Ti</strong></div>
+<div class="line"><strong>Si</strong></div>
 <div class="line">5th <a class="reference internal" href="functions.html#suggestive-func"><span class="std std-ref">Suggestive function</span></a></div>
 </div>
 </td>
@@ -247,12 +247,12 @@
 <td><p><a class="reference internal" href="model_a.html#superid-block"><span class="std std-ref">Super-id</span></a></p></td>
 </tr>
 <tr class="row-odd"><td><div class="line-block">
-<div class="line"><strong>Fe</strong></div>
+<div class="line"><strong>Ni</strong></div>
 <div class="line">7th <a class="reference internal" href="functions.html#ignoring-func"><span class="std std-ref">Ignoring function</span></a></div>
 </div>
 </td>
 <td><div class="line-block">
-<div class="line"><strong>Ti</strong></div>
+<div class="line"><strong>Te</strong></div>
 <div class="line">8th <a class="reference internal" href="functions.html#demonstrative-func"><span class="std std-ref">Demonstrative function</span></a></div>
 </div>
 </td>


### PR DESCRIPTION
originally said 1-Ne, 2-Ti, 3-Ti, 4-Fi, 5-Ti, 6-Fe, 7-Fe, and 8-Ti; changed to reflect accurate model A type

idk if I’m allowed to directly PR but whatever